### PR TITLE
Update makefile's flags

### DIFF
--- a/srcs/makefile-gen.rb
+++ b/srcs/makefile-gen.rb
@@ -169,7 +169,7 @@ def write_makefile(options, parsed_folder)
 
   # Adding the additionnal warning compilation flags
   if (parsed_folder.getCompiler != "nasm")
-    text << "#{compile_flag_name} += -W -Wall -Wextra\n"
+    text << "#{compile_flag_name} += -Wall -Wextra\n"
   end
 
   # Adding the werror restrictive compilation flag, transforming warning into errors


### PR DESCRIPTION
Rearrange the makefile flags who were misplaced or even obsolete, like the -W
man gcc's extract:
-Wextra
	This enables some extra warning flags that are not enabled by -Wall. (This option used to be called -W. The older name is still supported, but the newer name is more descriptive.)

It appear -W flags is the older name of -Wextra, so it's useless to let it the makefile.